### PR TITLE
[pr2-core/root/usr/lib/robot/robot.py] check and remove PID_FILE if not removed after robot stop

### DIFF
--- a/pr2-core/root/usr/lib/robot/robot.py
+++ b/pr2-core/root/usr/lib/robot/robot.py
@@ -249,6 +249,21 @@ def cmd_start(argv):
         else:
             subprocess.Popen(['roslaunch', '/etc/ros/robot.launch', '--pid', PID_FILE], env=env)
 
+        # check PID_FILE is writable from other users, and if not writable, change permission                       
+        start_time = time.time()
+        while not os.path.exists(PID_FILE):
+            if time.time() - start_time > 3.0:
+                print "%s not found." % PID_FILE
+                sys.exit(1)
+            time.sleep(0.1)
+        f_stat = os.stat(PID_FILE)
+        others_writable = bool(f_stat.st_mode & stat.S_IWOTH)
+        if not others_writable:
+            try:
+                os.chmod(PID_FILE, f_stat.st_mode | stat.S_IWOTH)
+            except OSError, e:
+                print "failed to append write permission to %s: (%d) %s" % (PID_FILE, e.errno, e.strerror)
+
         sys.exit(0)
 
 

--- a/pr2-core/root/usr/lib/robot/robot.py
+++ b/pr2-core/root/usr/lib/robot/robot.py
@@ -625,6 +625,11 @@ def ckill():
             for l in plist():
                 print l
         else:
+            if os.path.exists(PID_FILE):
+                try:
+                    os.remove(PID_FILE)
+                except OSError, e:
+                    print "%s still remains, but could not be removed.: (%d) %s" % (PID_FILE, e.errno, e.strerror)
             print "All processes killed successfully."
     else:
         print "No processes to kill."


### PR DESCRIPTION
`robot start` after another `robot start` may fails when the first roslaunch which is launched by `robot start` is killed by `SIGKILL` without removing its pid file, and the user's umask is 0002 (linux default).
This PR tries to remove file, and if not possible, outputs the warning.

c.f.: https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/150